### PR TITLE
Fix pip install on CI

### DIFF
--- a/environment-dev.yaml
+++ b/environment-dev.yaml
@@ -20,7 +20,7 @@ dependencies:
 
 # dev
 - black
-- pip
+- pip <21.3
 - pre-commit
 - pytest
 - pytest-cov


### PR DESCRIPTION
Currently, CI is failing when it is installing ibis-omniscidb with pip install --no-deps:

```
pip install --no-deps -e .
Obtaining file:///mnt/sda1/storage/dev/quansight/ibis-project/ibis-omniscidb
  Installing build dependencies ... done
  Getting requirements to build editable ... done
  Preparing editable metadata (pyproject.toml) ... done
  Build backend does not support editables, falling back to setup.py egg_info.
  Preparing metadata (setup.py) ... error
  ERROR: Command errored out with exit status 1:
   command: /mnt/sda1/storage/miniconda3/envs/ibis-omniscidb-dev/bin/python3.8 -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/mnt/sda1/storage/dev/quansight/ibis-project/ibis-omniscidb/setup.py'"'"'; __file__='"'"'/mnt/sda1/storage/dev/quansight/ibis-project/ibis-omniscidb/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-o3xcxbqw
       cwd: /mnt/sda1/storage/dev/quansight/ibis-project/ibis-omniscidb/
  Complete output (31 lines):
  /mnt/sda1/storage/miniconda3/envs/ibis-omniscidb-dev/bin/python3.8: No module named pip
  Traceback (most recent call last):
    File "/tmp/pip-build-env-7cpxex3j/overlay/lib/python3.8/site-packages/setuptools/installer.py", line 75, in fetch_build_egg
      subprocess.check_call(cmd)
    File "/mnt/sda1/storage/miniconda3/envs/ibis-omniscidb-dev/lib/python3.8/subprocess.py", line 364, in check_call
      raise CalledProcessError(retcode, cmd)
  subprocess.CalledProcessError: Command '['/mnt/sda1/storage/miniconda3/envs/ibis-omniscidb-dev/bin/python3.8', '-m', 'pip', '--disable-pip-version-check', 'wheel', '--no-deps', '-w', '/tmp/tmpt0agal8_', '--quiet', 'setuptools_scm']' returned non-zero exit status 1.
  
  The above exception was the direct cause of the following exception:
  
  Traceback (most recent call last):
    File "<string>", line 1, in <module>
    File "/mnt/sda1/storage/dev/quansight/ibis-project/ibis-omniscidb/setup.py", line 9, in <module>
      setuptools.setup(
    File "/tmp/pip-build-env-7cpxex3j/overlay/lib/python3.8/site-packages/setuptools/__init__.py", line 152, in setup
      _install_setup_requires(attrs)
    File "/tmp/pip-build-env-7cpxex3j/overlay/lib/python3.8/site-packages/setuptools/__init__.py", line 147, in _install_setup_requires
      dist.fetch_build_eggs(dist.setup_requires)
    File "/tmp/pip-build-env-7cpxex3j/overlay/lib/python3.8/site-packages/setuptools/dist.py", line 806, in fetch_build_eggs
      resolved_dists = pkg_resources.working_set.resolve(
    File "/tmp/pip-build-env-7cpxex3j/overlay/lib/python3.8/site-packages/pkg_resources/__init__.py", line 766, in resolve
      dist = best[req.key] = env.best_match(
    File "/tmp/pip-build-env-7cpxex3j/overlay/lib/python3.8/site-packages/pkg_resources/__init__.py", line 1051, in best_match
      return self.obtain(req, installer)
    File "/tmp/pip-build-env-7cpxex3j/overlay/lib/python3.8/site-packages/pkg_resources/__init__.py", line 1063, in obtain
      return installer(requirement)
    File "/tmp/pip-build-env-7cpxex3j/overlay/lib/python3.8/site-packages/setuptools/dist.py", line 877, in fetch_build_egg
      return fetch_build_egg(self, req)
    File "/tmp/pip-build-env-7cpxex3j/overlay/lib/python3.8/site-packages/setuptools/installer.py", line 77, in fetch_build_egg
      raise DistutilsError(str(e)) from e
  distutils.errors.DistutilsError: Command '['/mnt/sda1/storage/miniconda3/envs/ibis-omniscidb-dev/bin/python3.8', '-m', 'pip', '--disable-pip-version-check', 'wheel', '--no-deps', '-w', '/tmp/tmpt0agal8_', '--quiet', 'setuptools_scm']' returned non-zero exit status 1.
  ----------------------------------------
WARNING: Discarding file:///mnt/sda1/storage/dev/quansight/ibis-project/ibis-omniscidb. Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```

Pinning pip to <21.3 seems to fix the problem.