### PR TITLE
Add support for ibis 3

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,10 +22,10 @@ jobs:
       fail-fast: false
       matrix:
         ibis-version: ["<3", ">=3"]
-        deps-channel: ["stable", "dev"]
+        deps-channel: ["stable"]
         include:
-          - ibis-version: "<3"
-            deps-channel: ["stable"]
+          - ibis-version: ">=3"
+            deps-channel: ["dev"]
 
     defaults:
       run:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -2,7 +2,8 @@ name: Main
 
 on:
   push:
-    branches: main
+    branches:
+      - main
   pull_request:
 
 jobs:
@@ -16,7 +17,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        heavyai-version: ["stable", "dev"]
+        ibis-version: ["<3", ">=3"]
+        deps-channel: ["stable", "dev"]
+        include:
+          - ibis-version: "<3"
+            deps-channel: ["stable"]
 
     defaults:
       run:
@@ -44,7 +49,7 @@ jobs:
 
     - name: install dependencies
       run: |
-        if [[ "${{ matrix.heavyai-version }}" == "dev" ]]; then
+        if [[ "${{ matrix.deps-channel }}" == "dev" ]]; then
           python -m pip install git+https://github.com/heavyai/heavyai.git
           python -m pip install git+https://github.com/ibis-project/ibis.git
         fi
@@ -55,7 +60,3 @@ jobs:
 
     - name: run custom backend tests
       run: python -m pytest ibis_heavyai/tests -ra --junitxml=junit.xml --cov=ibis --cov-report=xml:coverage.xml
-
-    - name: run ibis backend tests
-      run: PYTEST_BACKENDS="heavyai" python -m pytest --pyargs ibis.backends.tests
-      if: always()

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     name: Tests HeavyDB

--- a/environment.yaml
+++ b/environment.yaml
@@ -7,12 +7,13 @@ dependencies:
 
 # core
 - python >=3.7
-- ibis-framework-core >=2.0, <3
+- ibis-framework-core >=2.0
 - heavyai
 - rbc >=0.8.0
 - pyarrow
 - regex
 - pandas
+- importlib_metadata
 
 # geo
 - geopandas

--- a/environment.yaml
+++ b/environment.yaml
@@ -14,6 +14,7 @@ dependencies:
 - regex
 - pandas
 - importlib_metadata
+- packaging
 
 # geo
 - geopandas

--- a/ibis_heavyai/operations.py
+++ b/ibis_heavyai/operations.py
@@ -20,9 +20,12 @@ from ibis.backends.base.sql.registry import (
     operation_registry,
     time_range_to_range_window,
 )
+from packaging.version import Version
 
 from . import dtypes as heavydb_dtypes
 from .identifiers import quote_identifier
+
+_ibis_legacy = Version(ibis.__version__) < Version("3.0")
 
 _sql_type_names = heavydb_dtypes.ibis_dtypes_str_to_sql
 
@@ -804,11 +807,11 @@ def _arbitrary(translator, expr):
 class NumericTruncate(ops.NumericBinaryOp):
     """Truncates x to y decimal places."""
 
-    try:
+    if _ibis_legacy:
+        output_type = rlz.shape_like('left', dt.float)
+    else:
         output_dtype = rlz.dtype_like('left')
         output_shape = rlz.shape_like('left')
-    except AttributeError:  # ibis<3
-        output_type = rlz.shape_like('left', dt.float)
 
 
 # GEOMETRIC
@@ -817,21 +820,21 @@ class NumericTruncate(ops.NumericBinaryOp):
 class Conv_4326_900913_X(ops.UnaryOp):
     """Converts WGS-84 latitude to WGS-84 Web Mercator x coordinate."""
 
-    try:
+    if _ibis_legacy:
+        output_type = rlz.shape_like('left', dt.float)
+    else:
         output_dtype = rlz.dtype_like('left')
         output_shape = rlz.shape_like('left')
-    except AttributeError:  # ibis<3
-        output_type = rlz.shape_like('left', dt.float)
 
 
 class Conv_4326_900913_Y(ops.UnaryOp):
     """Converts WGS-84 longitude to WGS-84 Web Mercator y coordinate."""
 
-    try:
+    if _ibis_legacy:
+        output_type = rlz.shape_like('left', dt.float)
+    else:
         output_dtype = rlz.dtype_like('left')
         output_shape = rlz.shape_like('left')
-    except AttributeError:  # ibis<3
-        output_type = rlz.shape_like('left', dt.float)
 
 
 # String

--- a/ibis_heavyai/operations.py
+++ b/ibis_heavyai/operations.py
@@ -804,8 +804,11 @@ def _arbitrary(translator, expr):
 class NumericTruncate(ops.NumericBinaryOp):
     """Truncates x to y decimal places."""
 
-    output_dtype = rlz.dtype_like('left')
-    output_shape = rlz.shape_like('left')
+    try:
+        output_dtype = rlz.dtype_like('left')
+        output_shape = rlz.shape_like('left')
+    except AttributeError:  # ibis<3
+        output_type = rlz.shape_like('left', dt.float)
 
 
 # GEOMETRIC
@@ -814,15 +817,21 @@ class NumericTruncate(ops.NumericBinaryOp):
 class Conv_4326_900913_X(ops.UnaryOp):
     """Converts WGS-84 latitude to WGS-84 Web Mercator x coordinate."""
 
-    output_dtype = rlz.dtype_like('left')
-    output_shape = rlz.shape_like('left')
+    try:
+        output_dtype = rlz.dtype_like('left')
+        output_shape = rlz.shape_like('left')
+    except AttributeError:  # ibis<3
+        output_type = rlz.shape_like('left', dt.float)
 
 
 class Conv_4326_900913_Y(ops.UnaryOp):
     """Converts WGS-84 longitude to WGS-84 Web Mercator y coordinate."""
 
-    output_dtype = rlz.dtype_like('left')
-    output_shape = rlz.shape_like('left')
+    try:
+        output_dtype = rlz.dtype_like('left')
+        output_shape = rlz.shape_like('left')
+    except AttributeError:  # ibis<3
+        output_type = rlz.shape_like('left', dt.float)
 
 
 # String

--- a/ibis_heavyai/operations.py
+++ b/ibis_heavyai/operations.py
@@ -804,7 +804,8 @@ def _arbitrary(translator, expr):
 class NumericTruncate(ops.NumericBinaryOp):
     """Truncates x to y decimal places."""
 
-    output_type = rlz.shape_like('left', dt.float)
+    output_dtype = rlz.dtype_like('left')
+    output_shape = rlz.shape_like('left')
 
 
 # GEOMETRIC
@@ -813,13 +814,15 @@ class NumericTruncate(ops.NumericBinaryOp):
 class Conv_4326_900913_X(ops.UnaryOp):
     """Converts WGS-84 latitude to WGS-84 Web Mercator x coordinate."""
 
-    output_type = rlz.shape_like('arg', dt.float)
+    output_dtype = rlz.dtype_like('left')
+    output_shape = rlz.shape_like('left')
 
 
 class Conv_4326_900913_Y(ops.UnaryOp):
     """Converts WGS-84 longitude to WGS-84 Web Mercator y coordinate."""
 
-    output_type = rlz.shape_like('arg', dt.float)
+    output_dtype = rlz.dtype_like('left')
+    output_shape = rlz.shape_like('left')
 
 
 # String
@@ -1082,7 +1085,6 @@ _date_ops = {
 # AGGREGATION/REDUCTION
 _agg_ops = {
     ops.HLLCardinality: approx_count_distinct,
-    ops.DistinctColumn: unary_prefix_op('distinct'),
     ops.Arbitrary: _arbitrary,
     ops.Sum: _reduction('sum'),
     ops.Mean: _reduction('avg'),

--- a/ibis_heavyai/tests/test_operations.py
+++ b/ibis_heavyai/tests/test_operations.py
@@ -115,7 +115,7 @@ def test_quote_name(alltypes, name):
 
 def test_timestamp_col(alltypes):
     # https://github.com/ibis-project/ibis/issues/1613
-    alltypes[alltypes.timestamp_col < '2000-03-01'].execute()
+    alltypes[alltypes.timestamp_col < ibis.timestamp('2000-03-01')].execute()
 
 
 @pytest.mark.parametrize(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "ibis-heavyai"
-version = "1.0"
+version = "1.1"
 requires-python = ">=3.7"
 authors = [{name = "Heavy.AI", email = "community@heavy.ai"}]
 description = "Ibis HeavyDB backend"
@@ -17,7 +17,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "ibis-framework >=2.0, <3",
+    "ibis-framework >=2.0",
     "heavyai",
     "rbc-project >=0.8.0",
     "pyarrow >=3.0.0",
@@ -54,7 +54,7 @@ name = "ibis_heavyai"
 
 [tool.flit.sdist]
 exclude = [
-    "ci/*", ".github/*", "*.yaml", ".*"
+    "ci/*", ".github/*", "*.yaml", ".*", "ibis_heavyai/tests/*", "docs/*"
 ]
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "shapely",
     "geopandas",
     "importlib_metadata",  # drop for python >3.7
+    "packaging"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ test = [
 ]
 
 dev = [
-    "heavyai[test]",
+    "ibis-heavyai[test]",
     "pre-commit",
     "flit"
 ]


### PR DESCRIPTION
Closes #67, closes #65

ibis 3 introduces breaking changes: https://ibis-project.org/docs/3.0.2/blog/Ibis-version-3.0.0-release

Notably for a user, there is no auto-casting: https://github.com/ibis-project/ibis/pull/3276

I also removed the testing registering the backend in ibis and running their tests because they changed the structure of their tests. After some trials, I don't know how to make this work (if does make sense as well. Tests in this repo should cover the features which are wanted).