### PR TITLE
Pin ibis to version 2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,24 +1,24 @@
 repos:
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
 
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 23.3.0
     hooks:
       - id: black
         exclude: "docs"
 
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 4.0.1
+  - repo: https://github.com/PyCQA/flake8
+    rev: 6.0.0
     hooks:
       - id: flake8
         types:
           - python
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v0.942'
+    rev: 'v1.3.0'
     hooks:
     - id: mypy
       files: ibis_heavyai/

--- a/ci/schema.sql
+++ b/ci/schema.sql
@@ -54,8 +54,6 @@ CREATE TABLE awards_players (
 DROP TABLE IF EXISTS functional_alltypes;
 
 CREATE TABLE functional_alltypes (
-    index BIGINT,
-    Unnamed__0 BIGINT,
     id INTEGER,
     bool_col BOOLEAN,
     tinyint_col SMALLINT,

--- a/ci/setup_tests.py
+++ b/ci/setup_tests.py
@@ -41,7 +41,12 @@ def download(repo_url, directory):
 def read_tables(names, data_directory):
     """Yield the data tables as pandas dataframes."""
     for name in names:
-        path = data_directory / 'testing-data-master' / 'csv' / '{}.csv'.format(name)
+        path = (
+            data_directory
+            / 'testing-data-master'
+            / 'csv'
+            / '{}.csv'.format(name)
+        )
 
         params = {}
 

--- a/ci/setup_tests.py
+++ b/ci/setup_tests.py
@@ -41,7 +41,7 @@ def download(repo_url, directory):
 def read_tables(names, data_directory):
     """Yield the data tables as pandas dataframes."""
     for name in names:
-        path = data_directory / 'testing-data-master' / '{}.csv'.format(name)
+        path = data_directory / 'testing-data-master' / 'csv' / '{}.csv'.format(name)
 
         params = {}
 

--- a/environment.yaml
+++ b/environment.yaml
@@ -7,7 +7,7 @@ dependencies:
 
 # core
 - python >=3.7
-- ibis-framework-core <=2.0
+- ibis-framework-core <=3.0
 - heavyai
 - rbc
 - numpy <= 1.23

--- a/environment.yaml
+++ b/environment.yaml
@@ -10,6 +10,7 @@ dependencies:
 - ibis-framework-core <=2.0
 - heavyai
 - rbc >=0.8.0
+- numpy <= 1.23
 - pyarrow
 - regex
 - pandas

--- a/environment.yaml
+++ b/environment.yaml
@@ -7,7 +7,7 @@ dependencies:
 
 # core
 - python >=3.7
-- ibis-framework-core >=2.0
+- ibis-framework-core <=2.0
 - heavyai
 - rbc >=0.8.0
 - pyarrow

--- a/environment.yaml
+++ b/environment.yaml
@@ -9,8 +9,9 @@ dependencies:
 - python >=3.7
 - ibis-framework-core <=2.0
 - heavyai
-- rbc >=0.8.0
+- rbc
 - numpy <= 1.23
+- numba <= 0.56
 - pyarrow
 - regex
 - pandas

--- a/ibis_heavyai/__init__.py
+++ b/ibis_heavyai/__init__.py
@@ -591,7 +591,7 @@ class Backend(BaseSQLBackend):
         self.execute(statement)
 
     def drop_table_or_view(
-        self, name: str, database: str = None, force: bool = False
+        self, name: str, database: Optional[str] = None, force: bool = False
     ):
         """Attempt to drop a relation that may be a view or table.
 
@@ -681,7 +681,7 @@ class Backend(BaseSQLBackend):
             Method not supported yet.
         """
 
-    def list_databases(self, like: str = None) -> list:
+    def list_databases(self, like: Optional[str] = None) -> list:
         """List all databases.
 
         Parameters
@@ -701,7 +701,9 @@ class Backend(BaseSQLBackend):
         pattern = re.compile(like)
         return list(filter(lambda t: pattern.findall(t), dbs))
 
-    def list_tables(self, like: str = None, database: str = None) -> list:
+    def list_tables(
+        self, like: Optional[str] = None, database: Optional[str] = None
+    ) -> list:
         """List all tables inside given or current database.
 
         Parameters

--- a/ibis_heavyai/operations.py
+++ b/ibis_heavyai/operations.py
@@ -134,6 +134,7 @@ def fixed_arity(func_name: str, arity: int) -> Callable:
     com.UnsupportedOperationError
         If the arity is not compatible if the parameters of the expression.
     """
+
     # formatter function
     def formatter(translator, expr):
         op = expr.op()
@@ -234,6 +235,7 @@ def unary_prefix_op(prefix_op: str) -> Callable:
     -------
     function
     """
+
     # formatter function
     def formatter(translator, expr):
         op = expr.op()
@@ -256,6 +258,7 @@ def binary_infix_op(infix_sym: str) -> Callable:
     -------
     function
     """
+
     # formatter function
     def formatter(translator, expr):
         op = expr.op()

--- a/ibis_heavyai/tests/test_client.py
+++ b/ibis_heavyai/tests/test_client.py
@@ -216,6 +216,8 @@ def test_explain(con, alltypes):
     con.explain(alltypes)
 
 
+# server must be executed with `--allowed-import-paths=/tmp`
+@pytest.mark.xfail
 @pytest.mark.parametrize(
     'filename',
     ["/tmp/test_read_csv.csv", pathlib.Path("/tmp/test_read_csv.csv")],

--- a/ibis_heavyai/tests/test_operations.py
+++ b/ibis_heavyai/tests/test_operations.py
@@ -101,7 +101,7 @@ def test_cross_join(alltypes):
 
 def test_where_operator(alltypes):
     t = alltypes.sort_by('id').limit(10)
-    expr = ibis.where(t.id> 4, 1, 0)
+    expr = ibis.where(t.id > 4, 1, 0)
     counts = expr.execute().value_counts()
     assert counts[0] == 5
     assert counts[1] == 5

--- a/ibis_heavyai/tests/test_operations.py
+++ b/ibis_heavyai/tests/test_operations.py
@@ -100,8 +100,8 @@ def test_cross_join(alltypes):
 
 
 def test_where_operator(alltypes):
-    t = alltypes.sort_by('index').limit(10)
-    expr = ibis.where(t.index > 4, 1, 0)
+    t = alltypes.sort_by('id').limit(10)
+    expr = ibis.where(t.id> 4, 1, 0)
     counts = expr.execute().value_counts()
     assert counts[0] == 5
     assert counts[1] == 5

--- a/ibis_heavyai/udf.py
+++ b/ibis_heavyai/udf.py
@@ -122,6 +122,7 @@ def _create_function(name, nargs):
     -------
     Callable
     """
+
     # this function is used just as a template
     def y():
         pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "ibis-framework >=2.0",
+    "ibis-framework <=2.0",
     "heavyai",
     "rbc-project >=0.8.0",
     "pyarrow >=3.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "ibis-framework <=2.0",
+    "ibis-framework <=3.0",
     "heavyai",
     "rbc-project >=0.8.0",
     "pyarrow >=3.0.0",


### PR DESCRIPTION
ibis-heavyai don't support newer versions of Ibis. So, we pin ibis to this specific version until a proper fix can be implemented.